### PR TITLE
Fix invalid profile join date rendering

### DIFF
--- a/apps/desktop/src/components/agents-ui/agent-chat-transcript.tsx
+++ b/apps/desktop/src/components/agents-ui/agent-chat-transcript.tsx
@@ -59,7 +59,9 @@ export function AgentChatTranscript({
           const locale = navigator?.language ?? 'en-US';
           const messageOrigin = from?.isLocal ? 'user' : 'assistant';
           const time = new Date(timestamp);
-          const title = time.toLocaleTimeString(locale, { timeStyle: 'full' });
+          const title = Number.isNaN(time.getTime())
+            ? ''
+            : time.toLocaleTimeString(locale, { timeStyle: 'full' });
 
           return (
             <Message key={id} title={title} from={messageOrigin}>

--- a/apps/web/app/dashboard/profile/page.tsx
+++ b/apps/web/app/dashboard/profile/page.tsx
@@ -41,6 +41,40 @@ async function apiFetch(path: string, options?: RequestInit) {
   });
 }
 
+function parseProfileDate(value: unknown): Date | null {
+  if (!value) return null;
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  if (typeof value === "object") {
+    const maybeTimestamp = value as {
+      _seconds?: number;
+      seconds?: number;
+      toDate?: () => Date;
+    };
+
+    if (typeof maybeTimestamp.toDate === "function") {
+      const parsed = maybeTimestamp.toDate();
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    const seconds = maybeTimestamp._seconds ?? maybeTimestamp.seconds;
+    if (typeof seconds === "number") {
+      const parsed = new Date(seconds * 1000);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+  }
+
+  return null;
+}
+
 export default function ProfilePage() {
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
@@ -50,6 +84,7 @@ export default function ProfilePage() {
     email?: string;
     phone?: string | null;
     createdAt?: unknown;
+    created_at?: unknown;
   } | null>(null);
   const [displayName, setDisplayName] = useState("");
   const [phone, setPhone] = useState("");
@@ -124,11 +159,8 @@ export default function ProfilePage() {
     }
   }
 
-  const createdAt = profile?.createdAt
-    ? new Date(
-        (profile.createdAt as { _seconds: number })._seconds * 1000,
-      ).toLocaleDateString()
-    : null;
+  const createdAtDate = parseProfileDate(profile?.createdAt ?? profile?.created_at);
+  const createdAt = createdAtDate ? createdAtDate.toLocaleDateString() : null;
 
   const initials = (user?.displayName || user?.email || "U")
     .split(" ")


### PR DESCRIPTION
## Summary
- fix profile `Member since` rendering by parsing multiple timestamp shapes instead of assuming Firestore `_seconds`
- support `Date`, string/number timestamps, Firestore `{_seconds|seconds}`, and `toDate()` sources
- include `created_at` fallback in profile payload handling
- harden desktop agent transcript timestamp title formatting to avoid invalid date/time output for malformed timestamps

## Test plan
- open dashboard profile and verify `Member since` renders for users with Firestore timestamps and ISO string dates
- verify no `Invalid Date` appears when profile date is malformed or absent
- verify desktop agent chat transcript renders without invalid timestamp tooltip text for malformed message timestamps